### PR TITLE
Redirect any unrecognized route to the index

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -106,10 +106,10 @@
 
 # # The following redirect is intended for use with most SPAs that handle
 # # routing internally.
-# [[redirects]]
-#   from = "/*"
-#   to = "/index.html"
-#   status = 200
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
 
 # [[headers]]
 #   # Define which paths this specific [[headers]] block will cover.


### PR DESCRIPTION
So that it can be handled by our JS routing